### PR TITLE
Deprecate post/windows/manage/smart_migrate and other things

### DIFF
--- a/modules/exploits/windows/winrm/winrm_script_exec.rb
+++ b/modules/exploits/windows/winrm/winrm_script_exec.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'WfsDelay'     => 30,
           'EXITFUNC' => 'thread',
-          'InitialAutoRunScript' => 'post/windows/manage/smart_migrate',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
           'CMDSTAGER::DECODER' => File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "vbs_b64_sleep")
         },
       'Platform'       => 'win',

--- a/modules/post/windows/manage/priv_migrate.rb
+++ b/modules/post/windows/manage/priv_migrate.rb
@@ -25,7 +25,11 @@ class Metasploit3 < Msf::Post
          then migrate to it. It will attempt the User level processes in the following order:
          NAME (if specified), explorer.exe, then notepad.exe.},
       'License'       => MSF_LICENSE,
-      'Author'        => ['Josh Hale <jhale85446[at]gmail.com>'],
+      'Author'        =>
+        [
+          'Josh Hale <jhale85446[at]gmail.com>',
+          'theLightCosine'
+        ],
       'Platform'      => ['win' ],
       'SessionTypes'  => ['meterpreter' ]
     ))

--- a/modules/post/windows/manage/smart_migrate.rb
+++ b/modules/post/windows/manage/smart_migrate.rb
@@ -8,6 +8,10 @@ require 'rex'
 
 class Metasploit3 < Msf::Post
 
+  include Msf::Module::Deprecated
+
+  deprecated(Date.new(2016, 2, 13), 'post/windows/manage/priv_migrate')
+
   def initialize(info={})
     super( update_info( info,
       'Name'          => 'Windows Manage Smart Process Migration',


### PR DESCRIPTION
This patch includes:
- Give credit to thelightcosine in priv_migrate
- Deprecate smart_migrate
- Update InitialAutoRunScript for winrm_script_exec

For https://github.com/rapid7/metasploit-framework/pull/6402
## Testing
- [ ] For testing, please run post/windows/manage/smart_migrate, and you should see this warning:

```
meterpreter > run post/windows/manage/smart_migrate

[!] ************************************************************************
[!] *        The module windows/manage/smart_migrate is deprecated!        *
[!] *              It will be removed on or about 2016-02-13               *
[!] *             Use post/windows/manage/priv_migrate instead             *
[!] ************************************************************************
...
```
